### PR TITLE
Fix DEV-6748 - Gray 'Create Chart' button style when disabled.

### DIFF
--- a/app/assets/stylesheets/dataset/_chart_configuration.scss
+++ b/app/assets/stylesheets/dataset/_chart_configuration.scss
@@ -52,6 +52,9 @@
         }
         font-size: 16px;
         font-weight: normal;
+        &:disabled {
+            color: $disabled-text;
+        }
     }
 
     .no_columns {


### PR DESCRIPTION
Added CSS that displays 'Create Chart' button text as gray if the button is disabled.