### PR TITLE
Further work for DEV-11378 Hive Data Source entry screen

### DIFF
--- a/app/assets/javascripts/dialogs/data_sources/data_source_edit_dialog.js
+++ b/app/assets/javascripts/dialogs/data_sources/data_source_edit_dialog.js
@@ -104,6 +104,8 @@ chorus.dialogs.DataSourceEdit = chorus.dialogs.Base.extend({
             delete attrs.hdfsVersion;
         }
 
+        attrs.connectionParameters = this.model.connectionParametersWithoutHadoopHive();
+
         attrs.highAvailability = !!this.$("input[name=high_availability]").prop("checked");
         attrs.ssl = !!this.$("input[name=ssl]").prop("checked");
 

--- a/app/assets/javascripts/dialogs/data_sources/data_source_edit_dialog.js
+++ b/app/assets/javascripts/dialogs/data_sources/data_source_edit_dialog.js
@@ -43,7 +43,7 @@ chorus.dialogs.DataSourceEdit = chorus.dialogs.Base.extend({
     },
 
     rewriteLink: function () {
-        this.$('a.connection_parameters').text(t('data_sources.dialog.connection_parameters', {count: this.model.numberOfConnectionParameters()}));
+        this.$('a.connection_parameters').text(t('data_sources.dialog.connection_parameters', {count: this.model.connectionParametersWithoutHadoopHive().length}));
     },
 
     toggleHighAvailability: function (e) {
@@ -76,7 +76,7 @@ chorus.dialogs.DataSourceEdit = chorus.dialogs.Base.extend({
             hdfsDataSource: this.model.constructorName === "HdfsDataSource",
             hdfsHiveDataSource: this.model.constructorName === "HdfsDataSource" && this.model.isHdfsHive(),
             gnipDataSource: this.model.constructorName === "GnipDataSource",
-            parameterCount: {count: this.model.numberOfConnectionParameters()},
+            parameterCount: {count: this.model.connectionParametersWithoutHadoopHive().length},
             jdbcHiveDataSource: this.model.constructorName === "JdbcHiveDataSource"
         };
     },

--- a/app/assets/javascripts/dialogs/data_sources/data_source_new_dialog.js
+++ b/app/assets/javascripts/dialogs/data_sources/data_source_new_dialog.js
@@ -26,13 +26,18 @@ chorus.dialogs.DataSourcesNew = chorus.dialogs.Base.extend ({
         }, this));
     },
 
+    // KT: August 2015 -- the way the DataSource dialogs work is very strange.  Here in the DataSourceNewDialog, all of
+    // the forms are backed by the 'AbstractDataSource' ... until they are submitted.  At that point the `createDataSource`
+    // method pulls the data out of the form, and creates a new model of the type you expect.
+    // Conversely -- in the DataSourceEditDialog, the form is backed by the correct (specific) DataSource type, always.
     makeModel: function () {
-        this.model = this.model || new chorus.models.GpdbDataSource();
+        this.model = this.model || new chorus.models.AbstractDataSource();
         this.listenTo(this.model, 'change', this.rewriteLink);
     },
 
     additionalContext: function() {
         var config = chorus.models.Config.instance();
+
         return {
             gnipConfigured: config.get('gnipConfigured'),
             oracleConfigured: config.get('oracleConfigured'),
@@ -143,7 +148,9 @@ chorus.dialogs.DataSourcesNew = chorus.dialogs.Base.extend ({
         updates.ssl = !!inputSource.find("input[name=ssl]").prop("checked");
         updates.shared = !!inputSource.find("input[name=shared]").prop("checked");
         updates.highAvailability = !!inputSource.find("input[name=high_availability]").prop("checked");
+
         updates.connectionParameters = this.model.get('connectionParameters');
+
         if(updates.hive) {
             updates.hiveKerberos = inputSource.find("input[name=hiveKerberos]:checked").val() === 'true';
             if (updates.hiveKerberos) {

--- a/app/assets/javascripts/dialogs/data_sources/hdfs_connection_parameters_dialog.js
+++ b/app/assets/javascripts/dialogs/data_sources/hdfs_connection_parameters_dialog.js
@@ -14,7 +14,11 @@ chorus.dialogs.HdfsConnectionParameters = chorus.dialogs.Base.extend({
     },
 
     setup: function () {
-        this.pairs = this.model.get('connectionParameters') || [{key: '', value: ''}];
+        this.pairs = this.model.connectionParametersWithoutHadoopHive();
+        if(this.pairs.length == 0) {
+          this.pairs = [{key: '', value: ''}];
+        }
+
         this.host_info = { host: '', port: 8088 };
     },
 
@@ -22,6 +26,7 @@ chorus.dialogs.HdfsConnectionParameters = chorus.dialogs.Base.extend({
         e && e.preventDefault();
 
         this.preservePairs();
+
         this.model.set('connectionParameters', this.pairs);
 
         if (this.validatePairs() === true) {
@@ -35,9 +40,15 @@ chorus.dialogs.HdfsConnectionParameters = chorus.dialogs.Base.extend({
         // Perform manual validation
         var validation_errors = {};
         for (var k in this.pairs) {
+            var key = this.pairs[k].key.trim();
+
             // Don't allow any key to be blank.
-            if (this.pairs[k].key.trim() === '') {
+            if (key === '') {
                 validation_errors['key_' + k] = t('validation.required', {fieldName: "Key"});
+            }
+
+            if (key === 'is_hive' || key === 'hive.metastore.uris') {
+              validation_errors['key_' + k] = t('data_sources.dialog.validation.hadoop_hive_keys_not_allowed');
             }
         }
 

--- a/app/assets/javascripts/models/abstract_data_source.js
+++ b/app/assets/javascripts/models/abstract_data_source.js
@@ -88,5 +88,23 @@ chorus.models.AbstractDataSource = chorus.models.Base.extend({
 
     usage: function() {
         return false;
+    },
+
+    // KT TODO refactor: the two methods following, belong more in HdfsDataSource -- but, it's difficult to get that
+    // to work, due to the way that the DataSourceNewDialog is written.
+    numberOfConnectionParameters: function() {
+        return this.connectionParametersWithoutHadoopHive().length;
+    },
+    connectionParametersWithoutHadoopHive: function() {
+      var pairs = this.get('connectionParameters');
+
+      pairs = _.map(pairs, function (pair) {
+        if(pair['key'] != 'is_hive' && pair['key'] != 'hive.metastore.uris') {
+          return pair;
+        }
+      });
+      pairs = _.compact(pairs);
+
+      return pairs;
     }
 });

--- a/app/assets/javascripts/models/abstract_data_source.js
+++ b/app/assets/javascripts/models/abstract_data_source.js
@@ -88,10 +88,5 @@ chorus.models.AbstractDataSource = chorus.models.Base.extend({
 
     usage: function() {
         return false;
-    },
-
-    numberOfConnectionParameters: function () {
-        var connectionParams = this.get('connectionParameters');
-        return connectionParams ? connectionParams.length : 0;
     }
 });

--- a/app/assets/javascripts/models/hdfs_data_source.js
+++ b/app/assets/javascripts/models/hdfs_data_source.js
@@ -42,10 +42,12 @@ chorus.models.HdfsDataSource = chorus.models.AbstractDataSource.extend({
         this.require("host", newAttrs);
         this.require("username", newAttrs);
         this.require("groupList", newAttrs);
+
         if (newAttrs.highAvailability === 'false') {
             this.require("port", newAttrs);
             this.requirePattern("port", chorus.ValidationRegexes.OnlyDigits(), newAttrs);
         }
+
         if (newAttrs.jobTrackerHost || newAttrs.jobTrackerPort) {
             this.require("jobTrackerHost", newAttrs);
             this.require("jobTrackerPort", newAttrs);
@@ -59,19 +61,6 @@ chorus.models.HdfsDataSource = chorus.models.AbstractDataSource.extend({
 
     version: function() {
         return this.get("hdfsVersion");
-    },
-
-    connectionParametersWithoutHadoopHive: function() {
-      var pairs = this.get('connectionParameters');
-
-      pairs = _.map(pairs, function (pair) {
-        if(pair['key'] != 'is_hive' && pair['key'] != 'hive.metastore.uris') {
-          return pair;
-        }
-      });
-      pairs = _.compact(pairs);
-
-      return pairs;
     }
 
 });

--- a/app/assets/javascripts/models/hdfs_data_source.js
+++ b/app/assets/javascripts/models/hdfs_data_source.js
@@ -5,6 +5,11 @@ chorus.models.HdfsDataSource = chorus.models.AbstractDataSource.extend({
     shared: true,
     entityType: "hdfs_data_source",
 
+    beforeSave: function() {
+      this._super("beforeSave");
+      this.set('connectionParameters', this.connectionParametersWithoutHadoopHive());
+    },
+
     isShared: function() {
         return true;
     },
@@ -59,6 +64,19 @@ chorus.models.HdfsDataSource = chorus.models.AbstractDataSource.extend({
 
     version: function() {
         return this.get("hdfsVersion");
+    },
+
+    connectionParametersWithoutHadoopHive: function() {
+      var pairs = this.get('connectionParameters');
+
+      pairs = _.map(pairs, function (pair) {
+        if(pair['key'] != 'is_hive' && pair['key'] != 'hive.metastore.uris') {
+          return pair;
+        }
+      });
+      pairs = _.compact(pairs);
+
+      return pairs;
     }
 
 });

--- a/app/assets/javascripts/models/hdfs_data_source.js
+++ b/app/assets/javascripts/models/hdfs_data_source.js
@@ -5,11 +5,6 @@ chorus.models.HdfsDataSource = chorus.models.AbstractDataSource.extend({
     shared: true,
     entityType: "hdfs_data_source",
 
-    beforeSave: function() {
-      this._super("beforeSave");
-      this.set('connectionParameters', this.connectionParametersWithoutHadoopHive());
-    },
-
     isShared: function() {
         return true;
     },

--- a/app/models/hdfs_data_source.rb
+++ b/app/models/hdfs_data_source.rb
@@ -70,12 +70,14 @@ class HdfsDataSource < ActiveRecord::Base
   def connection_parameters_including_hive
     return unless connection_parameters
 
+    params = connection_parameters.clone
+
     if is_hdfs_hive
-      connection_parameters << {"key" => "is_hive", "value" => "true"}
-      connection_parameters << {"key" => 'hive.metastore.uris', "value" => hive_metastore_location}
+      params << {"key" => "is_hive", "value" => "true"}
+      params << {"key" => 'hive.metastore.uris', "value" => hive_metastore_location}
     end
 
-    connection_parameters
+    params
   end
 
   def hdfs_pairs

--- a/app/presenters/hdfs_data_source_presenter.rb
+++ b/app/presenters/hdfs_data_source_presenter.rb
@@ -23,7 +23,7 @@ class HdfsDataSourcePresenter < Presenter
           :job_tracker_host => model.job_tracker_host,
           :job_tracker_port => model.job_tracker_port,
           :high_availability => model.high_availability?,
-          :connection_parameters => model.connection_parameters
+          :connection_parameters => model.connection_parameters_including_hive
       }.merge(owner_hash).
       merge(tags_hash))
     end

--- a/db/migrate/20150727220701_add_hive_metastore_location_to_hdfs_data_source.rb
+++ b/db/migrate/20150727220701_add_hive_metastore_location_to_hdfs_data_source.rb
@@ -4,6 +4,31 @@ class AddHiveMetastoreLocationToHdfsDataSource < ActiveRecord::Migration
       t.boolean :is_hdfs_hive
       t.string :hive_metastore_location
     end
+
+    HdfsDataSource.reset_column_information
+
+    # KT: Migrate these values out of the connection_parameters hash.  Chester has told me that no customers will have them,
+    # but let's be neat, and save the effort for our QA team and servers.
+    HdfsDataSource.all.each do |ds|
+
+      searchable_hash = Hash[ds.connection_parameters.map { |h| [h["key"], h["value"]] }]
+
+      if searchable_hash.keys.include? 'is_hive'
+        array = ds.connection_parameters.select{|hash| hash['key'] == 'is_hive'}
+        hash = array.first
+        ds.is_hdfs_hive = hash['value']
+        ds.connection_parameters -= array
+      end
+
+      if searchable_hash.keys.include? 'hive.metastore.uris'
+        array = ds.connection_parameters.select{|hash| hash['key'] == 'hive.metastore.uris'}
+        hash = array.first
+        ds.hive_metastore_location = hash['value']
+        ds.connection_parameters -= array
+      end
+
+      ds.save if ds.changed?
+    end
   end
 
   def down
@@ -12,4 +37,5 @@ class AddHiveMetastoreLocationToHdfsDataSource < ActiveRecord::Migration
       t.remove :hive_metastore_location
     end
   end
+
 end

--- a/public/messages/Messages_en.properties
+++ b/public/messages/Messages_en.properties
@@ -1080,7 +1080,7 @@ help.help_and_support.sub_title_2=Log Files
 
 help.help_and_support.button.download_logs=Download Logs
 #help.help_and_support.logs_download_message=<p>The application log files can help diagnose the issue. Download them here. Still don't know what to do? Email the log files to Technical Support for assistance.</p>
-help.help_and_support.logs_download_message=The application log files include information that will help us troubleshoot and diagnose your issue. If requested, please download the log files here and email them to Alpine Technical Support (support@alpinenow.com) 
+help.help_and_support.logs_download_message=The application log files include information that will help us troubleshoot and diagnose your issue. If requested, please download the log files here and email them to Alpine Technical Support (support@alpinenow.com)
 
 
 
@@ -1206,6 +1206,8 @@ data_sources.dialog.gnip_password=Gnip Password
 data_sources.dialog.gnip_help_text=To use your account's stream, enter the stream URL supplied to you by Gnip
 data_sources.dialog.gnip_url=Gnip Stream URL
 data_sources.dialog.hdfs_version=Hadoop Version
+data_sources.dialog.validation.hadoop_hive_keys_not_allowed=Hadoop Hive related key not allowed. Configure this by creating a Hadoop Hive Data Source.
+
 data_sources.edit_dialog.save=Save Configuration
 data_sources.edit_dialog.saved.toast=Settings for <span class="message_callout">{{dataSourceName}}</span> were updated
 data_sources.edit_dialog.saving=Saving

--- a/spec/presenters/hdfs_data_source_presenter_spec.rb
+++ b/spec/presenters/hdfs_data_source_presenter_spec.rb
@@ -2,58 +2,82 @@ require 'spec_helper'
 
 describe HdfsDataSourcePresenter, :type => :view do
   let(:hdfs_data_source) { hdfs_data_sources(:hadoop) }
-  let(:user) { hdfs_data_source.owner }
-  let(:presenter) { HdfsDataSourcePresenter.new(hdfs_data_source, view, options) }
   let(:options) { {} }
+  let(:user) { hdfs_data_source.owner }
 
   before do
     set_current_user(user)
   end
 
   describe "#to_hash" do
-    let(:hash) { presenter.to_hash }
 
-    it "should have the correct keys" do
-      hash.should have_key(:name)
-      hash.should have_key(:host)
-      hash.should have_key(:port)
-      hash.should have_key(:id)
-      hash.should have_key(:is_deleted)
-      hash.should have_key(:owner)
-      hash.should have_key(:description)
-      hash.should have_key(:version)
-      hash.should have_key(:username)
-      hash.should have_key(:group_list)
-      hash.should have_key(:online)
-      hash.should have_key(:tags)
-      hash.should have_key(:supports_work_flows)
-      hash.should have_key(:job_tracker_host)
-      hash.should have_key(:job_tracker_port)
-      hash.should have_key(:hdfs_version)
-      hash.should have_key(:high_availability)
-      hash.should have_key(:connection_parameters)
-      hash[:entity_type].should == 'hdfs_data_source'
-    end
-
-    it "presents an empty array when there are no additional connection parameters" do
-      hash[:connection_parameters].should == []
-    end
-
-    it "should use ownerPresenter Hash method for owner" do
-      owner = hash[:owner]
-      owner.to_hash.should == (UserPresenter.new(user, view).presentation_hash)
-    end
-
-    it_behaves_like "activity stream data source presenter"
-    it_behaves_like :succinct_data_source_presenter
-
-    context "in succinct mode" do
-      let(:options) { { :succinct => true } }
+    context "when HdfsDataSource is_hdfs_hive is false" do
+      let(:presenter) { HdfsDataSourcePresenter.new(hdfs_data_source, view, options) }
+      let(:hash) { presenter.to_hash }
 
       it "should have the correct keys" do
+        hash.should have_key(:name)
+        hash.should have_key(:host)
+        hash.should have_key(:port)
+        hash.should have_key(:id)
+        hash.should have_key(:is_deleted)
+        hash.should have_key(:owner)
+        hash.should have_key(:description)
+        hash.should have_key(:version)
+        hash.should have_key(:username)
+        hash.should have_key(:group_list)
+        hash.should have_key(:online)
+        hash.should have_key(:tags)
         hash.should have_key(:supports_work_flows)
+        hash.should have_key(:job_tracker_host)
+        hash.should have_key(:job_tracker_port)
         hash.should have_key(:hdfs_version)
+        hash.should have_key(:high_availability)
+        hash.should have_key(:connection_parameters)
+        hash[:entity_type].should == 'hdfs_data_source'
+      end
+
+      it "presents an empty array when there are no additional connection parameters" do
+        hash[:connection_parameters].should == []
+      end
+
+      it "should use ownerPresenter Hash method for owner" do
+        owner = hash[:owner]
+        owner.to_hash.should == (UserPresenter.new(user, view).presentation_hash)
+      end
+
+      it_behaves_like "activity stream data source presenter"
+      it_behaves_like :succinct_data_source_presenter
+
+      context "in succinct mode" do
+        let(:options) { {:succinct => true} }
+
+        it "should have the correct keys" do
+          hash.should have_key(:supports_work_flows)
+          hash.should have_key(:hdfs_version)
+        end
       end
     end
+
+    context "when HdfsDataSource is_hdfs_hive is true" do
+      let(:hdfs_hive_data_source) { hdfs_data_sources(:hdfs_hive) }
+      let(:hive_presenter) { HdfsDataSourcePresenter.new(hdfs_hive_data_source, view, options) }
+      let(:hash) { hive_presenter.to_hash }
+
+      it "should have the correct keys" do
+
+        hash.should have_key(:is_hdfs_hive)
+        hash[:is_hdfs_hive].should be_true
+
+        hash.should have_key(:hive_metastore_location)
+        hash[:hive_metastore_location].should_not be_empty
+
+        hash.should have_key(:connection_parameters)
+        hash[:connection_parameters].should_not be_empty
+        hash[:connection_parameters].select{|a| a['key'] == 'is_hive'}.should be_true
+        hash[:connection_parameters].select{|a| a['key'] == 'hive.metastore.uris'}.should be_present
+      end
+    end
+
   end
 end

--- a/spec/support/fixture_builder.rb
+++ b/spec/support/fixture_builder.rb
@@ -100,8 +100,6 @@ FixtureBuilder.configure do |fbuilder|
     Events::UserAdded.by(user_with_restricted_access).add(:new_user => user_with_restricted_access)
 
 
-
-
     #Data Sources
     gpdb_data_source = FactoryGirl.create(:gpdb_data_source, :name => "searchquery", :description => "Just for searchquery and greenplumsearch", :host => "non.legit.example.com", :port => "5432", :db_name => "postgres", :owner => admin)
     fbuilder.name :default, gpdb_data_source
@@ -157,6 +155,9 @@ FixtureBuilder.configure do |fbuilder|
 
     fbuilder.name :searchable, HdfsEntry.create!({:path => "/searchquery/result.txt", :size => 10, :is_directory => false, :modified_at => "2010-10-20 22:00:00", :content_count => 4, :hdfs_data_source => hdfs_data_source}, :without_protection => true)
     fbuilder.name :searchable2, HdfsEntry.create!({:path => "/searchquery/other_result.txt", :size => 11, :is_directory => false, :modified_at => "2010-10-21 22:00:00", :content_count => 22, :hdfs_data_source => hdfs_data_source}, :without_protection => true)
+
+    hdfs_hive_data_source = FactoryGirl.create(:hdfs_data_source, :name => 'hdfs_hive', :is_hdfs_hive => true,
+                                               :hive_metastore_location => "thrift://cdh5cm.alpinenow.local:9083", :owner => admin)
 
     gnip_data_source = FactoryGirl.create(:gnip_data_source, :owner => owner, :name => "default", :description => "a searchquery example gnip account")
     FactoryGirl.create(:gnip_data_source, :owner => owner, :name => 'typeahead_gnip')
@@ -303,14 +304,14 @@ FixtureBuilder.configure do |fbuilder|
     # Tableau publications
     publication = with_current_user(owner) do
       FactoryGirl.create :tableau_workbook_publication, :name => "default",
-                                       :workspace => public_workspace, :dataset => chorus_view, :project_name => "Default"
+                         :workspace => public_workspace, :dataset => chorus_view, :project_name => "Default"
     end
 
     tableau_workfile = LinkedTableauWorkfile.create({:file_name => 'tableau',
-                                  :workspace => public_workspace,
-                                  :owner => owner,
-                                  :tableau_workbook_publication => publication
-                                 }, :without_protection => true)
+                                                     :workspace => public_workspace,
+                                                     :owner => owner,
+                                                     :tableau_workbook_publication => publication
+                                                    }, :without_protection => true)
 
     LinkedTableauWorkfile.create({:file_name => 'searchquery',
                                   :workspace => public_workspace,
@@ -319,32 +320,32 @@ FixtureBuilder.configure do |fbuilder|
                                  }, :without_protection => true)
 
     private_tableau_workfile = LinkedTableauWorkfile.create({:file_name => 'private_tableau',
-                                                     :workspace => private_workspace,
-                                                     :owner => owner,
-                                                     :tableau_workbook_publication => nil
-                                                    }, :without_protection => true)
+                                                             :workspace => private_workspace,
+                                                             :owner => owner,
+                                                             :tableau_workbook_publication => nil
+                                                            }, :without_protection => true)
 
     fbuilder.name :owner_creates_tableau_workfile, Events::TableauWorkfileCreated.by(owner).add(
-        :workbook_name => publication.name,
-        :dataset => publication.dataset,
-        :workspace => publication.workspace,
-        :workfile => tableau_workfile
-    )
+                                                   :workbook_name => publication.name,
+                                                   :dataset => publication.dataset,
+                                                   :workspace => publication.workspace,
+                                                   :workfile => tableau_workfile
+                                                 )
 
     #Alpine workfile
 
     work_flow = AlpineWorkfile.create!({:file_name => 'alpine_flow',
-                                     :workspace => public_workspace,
-                                     :owner => owner,
-                                     :dataset_ids => %w(1 2 3),
-                                    }, :without_protection => true)
+                                        :workspace => public_workspace,
+                                        :owner => owner,
+                                        :dataset_ids => %w(1 2 3),
+                                       }, :without_protection => true)
     work_flow.workfile_execution_locations.create(execution_location: default_database)
 
     hadoop_work_flow = AlpineWorkfile.create!({:file_name => 'alpine_hadoop_dataset_flow',
-                            :workspace => public_workspace,
-                            :owner => owner,
-                            :dataset_ids => HdfsDataset.limit(3).pluck(:id),
-                           }, :without_protection => true)
+                                               :workspace => public_workspace,
+                                               :owner => owner,
+                                               :dataset_ids => HdfsDataset.limit(3).pluck(:id),
+                                              }, :without_protection => true)
     hadoop_work_flow.workfile_execution_locations.create!(execution_location: hdfs_data_source)
 
     oracle_work_flow = AlpineWorkfile.create!({:file_name => 'alpine_oracle_flow',
@@ -533,8 +534,8 @@ FixtureBuilder.configure do |fbuilder|
     fbuilder.name :one, previous_import
 
     import_now = FactoryGirl.create(:import, :user => owner, :workspace => public_workspace, :to_table => "new_table_for_import",
-                                         :created_at => '2012-09-03 23:00:00-07',
-                                         :source => default_table)
+                                    :created_at => '2012-09-03 23:00:00-07',
+                                    :source => default_table)
     fbuilder.name :now, import_now
 
     other_schema = FactoryGirl.create(:gpdb_schema, database: default_database)
@@ -550,7 +551,7 @@ FixtureBuilder.configure do |fbuilder|
     fbuilder.name :csv, csv_import
 
     fbuilder.name :gnip, FactoryGirl.create(:gnip_import, :user => owner, :workspace => public_workspace, :to_table => "gnip_import_table",
-                                    :source => gnip_data_source)
+                                            :source => gnip_data_source)
 
     #Notes
     with_current_user(owner) do
@@ -686,10 +687,10 @@ FixtureBuilder.configure do |fbuilder|
       @gpdb_workspace.source_datasets << test_schema2.active_tables_and_views.first
 
       real_chorus_view = FactoryGirl.create(:chorus_view,
-                                               :name => "real_chorus_view",
-                                               :schema => test_schema,
-                                               :query => "select 1",
-                                               :workspace => real_workspace)
+                                            :name => "real_chorus_view",
+                                            :schema => test_schema,
+                                            :query => "select 1",
+                                            :workspace => real_workspace)
     end
 
     if ENV['PG_HOST']
@@ -747,6 +748,7 @@ FixtureBuilder.configure do |fbuilder|
 
     bad_users = User.select { |u| u.username.starts_with?('user') }
     if !bad_users.empty?
+      p bad_users
       raise "OH NO!  A user was created with an autogenerated name. All users created in fixtures should be named! Perhaps a factory ran amok?"
     end
 


### PR DESCRIPTION
This is to fix: https://alpine.atlassian.net/browse/DEV-11915

* Mike Souza helped me to figure out that, we need to also modify the 'connection_parameters' in the JSON API, as our application communicates with Hadoop in 2 ways: from Chorus -> Hadoop, and
from Chorus -> Alpine -> Hadoop.  Alpine gets the connection_parameters from the Chorus API.  So, I take care of this.

* We must also modify the UI to work around the fact that these fields are moved from connection_parameters and into their own columns.  I add "validations" to the form to make it so that these keys cannot be added as "connection_parameters" (because, otherwise we have a "source of truth" problem.)  I also add a migration to move any instances of these fields out of the connection_parameters column, and into their distinct columns.