### PR TITLE
Fix for [DEV-12060] Re-running migrate_permissions after upgrade fails

### DIFF
--- a/app/models/chorus_object.rb
+++ b/app/models/chorus_object.rb
@@ -6,7 +6,7 @@ class ChorusObject < ActiveRecord::Base
   belongs_to :chorus_class
   belongs_to :chorus_scope
   belongs_to :owner, :class_name => "User"
-  has_many :chorus_object_roles, :dependent => :destroy
+  has_many :chorus_object_roles, :dependent => :destroy, :uniq => true
   #has_many :roles, :through => :chorus_object_roles
   #has_many :permissions, :through => :roles
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -142,7 +142,9 @@ class User < ActiveRecord::Base
 
       admin_role.users << self unless admin_role.users.include? self
       app_manager_role.users << self unless app_manager_role.users.include? self
-      site_admin_role.users << self unless site_admin_role.users.include? self || self.username != chorusadmin
+      if self.username == 'chorusadmin'
+        site_admin_role.users << self unless site_admin_role.users.include? self
+      end
       write_attribute(:admin, value)
 
     elsif value == false || value == "false"

--- a/db/migrate_permissions.rb
+++ b/db/migrate_permissions.rb
@@ -89,7 +89,10 @@ User.find_in_batches({:batch_size => 5}) do |users|
     end
     print '.'
     user_object = ChorusObject.create(:chorus_class_id => ChorusClass.find_by_name(user.class.name).id, :instance_id => user.id, :chorus_scope_id => application_realm.id)
-    user_object.chorus_object_roles << ChorusObjectRole.create(:chorus_object_id => user_object.id, :user_id => user.id, :role_id => user_role.id)
+    object_role = ChorusObjectRole.create(:chorus_object_id => user_object.id, :user_id => user.id, :role_id => user_role.id)
+    user_object.chorus_object_roles << object_role unless user_object.chorus_object_roles.include? object_role
+
+    #user_object.chorus_object_roles << ChorusObjectRole.create(:chorus_object_id => user_object.id, :user_id => user.id, :role_id => user_role.id)
 
     #user_object_role = ChorusObjectRole.create(:chorus_object_id => user_object.id, :user_id => user.id, :role_id => user_role.id)
     # add all users to default scope (application realm) by adding user to the default group
@@ -240,11 +243,17 @@ Workspace.find_in_batches({:batch_size => 5}) do |workspaces|
     # Add owner as workspace role
     print '.'
     workspace_object = ChorusObject.create(:chorus_class_id => ChorusClass.find_by_name(workspace.class.name).id, :instance_id => workspace.id, :owner_id => workspace.owner.id, :chorus_scope_id => application_realm.id)
-    workspace_object.chorus_object_roles << ChorusObjectRole.create(:chorus_object_id => workspace_object.id, :user_id => workspace.owner.id, :role_id => owner_role.id)
+    object_role = ChorusObjectRole.create(:chorus_object_id => workspace_object.id, :user_id => workspace.owner.id, :role_id => owner_role.id)
+    workspace_object.chorus_object_roles << object_role unless workspace_object.chorus_object_roles.include? object_role
+    #workspace_object.chorus_object_roles << ChorusObjectRole.create(:chorus_object_id => workspace_object.id, :user_id => workspace.owner.id, :role_id => owner_role.id)
 
     # Add members as Project Managers
     workspace.members.each do |member|
-      workspace_object.add_user_to_object_role(member, project_manager_role)
+      object_role = ChorusObjectRole.create(:chorus_object_id => workspace_object.id, :user_id => member.id, :role_id => project_manager_role.id)
+      workspace_object.chorus_object_roles << object_role unless  workspace_object.chorus_object_roles.include? object_role
+
+      #workspace_object.chorus_object_roles << ChorusObjectRole.create(:chorus_object_id => workspace_object.id, :user_id => member.id, :role_id => project_manager_role.id)
+      #workspace_object.add_user_to_object_role(member, project_manager_role)
     end
 
     #workspace_object_role = ChorusObjectRole.create(:chorus_object_id => workspace_object.id, :user_id => workspace.owner.id, :role_id => owner_role.id)


### PR DESCRIPTION
@AndrewLngdn 
I want to review this PR with you. I am not sure why you did not use standard rails method for creating and destroying chorus_object_roles. After I made these changes, migrate_permissions seems to work in all scenarios (fresh install, upgrade, running multiple times, etc.)

