### PR TITLE
Fixed DEV-11057 bug relating to deleting tags

### DIFF
--- a/app/assets/javascripts/pages/tags/tag_index_page.js
+++ b/app/assets/javascripts/pages/tags/tag_index_page.js
@@ -14,6 +14,11 @@ chorus.pages.TagIndexPage = chorus.pages.Base.extend({
 
         this.handleFetchErrorsFor(tags);
         this.listenTo(tags, "loaded", this.render);
-        this.listenTo(tags, "remove", this.render);
+
+        this.listenTo(tags, "remove", function (tag) {
+          chorus.PageEvents.trigger('clear_selection', tag);
+          this.render();
+        });
+
     }
 });

--- a/app/assets/javascripts/pages/tags/tag_list_sidebar.js
+++ b/app/assets/javascripts/pages/tags/tag_list_sidebar.js
@@ -14,6 +14,11 @@ chorus.views.TagListSidebar = chorus.views.Sidebar.extend({
         this.subscribePageEvent('tag:deselected', function() {
             this.setTag(null);
         });
+
+        // When a tag is deleted, make sure it disappears from the sidebar.
+        this.subscribePageEvent('tag:deleted', function() {
+            this.setTag(null);
+        });
     },
 
     setTag: function(tag) {

--- a/app/assets/javascripts/pages/tags/tag_list_sidebar.js
+++ b/app/assets/javascripts/pages/tags/tag_list_sidebar.js
@@ -14,8 +14,6 @@ chorus.views.TagListSidebar = chorus.views.Sidebar.extend({
         this.subscribePageEvent('tag:deselected', function() {
             this.setTag(null);
         });
-
-        // When a tag is deleted, make sure it disappears from the sidebar.
         this.subscribePageEvent('tag:deleted', function() {
             this.setTag(null);
         });


### PR DESCRIPTION
With this fix, the behavior when deleting the first or last tag in the tag list is that the sidebar becomes blank, which is the correct behavior. When deleting a tag other than the first one, the behavior is that the next tag in the list becomes selected (same behavior as before).

Ideally, the sidebar should always become blank after deleting a tag, but I could not figure out how to get this behavior. This is related to the "selectedIndex" of the tag list not being updated after deleting a tag.