### PR TITLE
DEV-9045 - Fix permissions on multi-job select sidebar

### DIFF
--- a/app/assets/javascripts/templates/multiple_selection_sidebar_menu.hbs
+++ b/app/assets/javascripts/templates/multiple_selection_sidebar_menu.hbs
@@ -1,12 +1,14 @@
-{{#if actions}}
-    <label>{{t "sidebar.selected" count=modelCount}}</label>
-    <div class="actions">
-        <ul class="multiselect_actions">
-            {{#each actions}}
-                <li class="action">
-                    <a href="#" class="{{name}}">{{message}}</a>
-                </li>
-            {{/each}}
-        </ul>
-    </div>
+{{#if canUpdateSelected}}
+    {{#if actions}}
+        <label>{{t "sidebar.selected" count=modelCount}}</label>
+        <div class="actions">
+            <ul class="multiselect_actions">
+                {{#each actions}}
+                    <li class="action">
+                        <a href="#" class="{{name}}">{{message}}</a>
+                    </li>
+                {{/each}}
+            </ul>
+        </div>
+    {{/if}}
 {{/if}}

--- a/app/assets/javascripts/views/multiple_selection_sidebar_menu.js
+++ b/app/assets/javascripts/views/multiple_selection_sidebar_menu.js
@@ -47,7 +47,16 @@ chorus.views.MultipleSelectionSidebarMenu = chorus.views.Base.include(
 
         additionalContext: function () {
             var actions = _.map(this.actions, this.templateValues);
+
+            // Only show the list of actions in the sidebar (Disable, Enable, Delete)
+            // if the currently logged in user has permissions to
+            // update ALL of the currently selected jobs.
+            var canUpdateSelected = this.selectedModels.every(function (selectedModel){
+                return selectedModel.workspace().canUpdate();
+            });
+
             return {
+                canUpdateSelected: canUpdateSelected,
                 selectedModels: this.selectedModels,
                 modelCount: this.selectedModels.length,
                 actions: actions

--- a/app/assets/javascripts/views/workfiles/worklets/worklet_inputs_configuration_view.js
+++ b/app/assets/javascripts/views/workfiles/worklets/worklet_inputs_configuration_view.js
@@ -156,6 +156,9 @@ chorus.views.WorkletInputsConfiguration = chorus.views.Base.extend({
             // Use the "worklet parameter" model's end-point when saving
             var generic = new chorus.models.WorkletParameter(param_model);
             var save_state = false !== generic.save(updates, save_options);
+            if (save_state === true) {
+                this.parameters.models[i] = generic;
+            }
 
             this.paramChanged();
             return save_state;


### PR DESCRIPTION
This change fixes a bug where if am a non-admin, non-member, non owner of a workspace, the right hand side panel is enabled with actions when I select multiple jobs, but should not be.

This fix adds a check for the permissions of the current user against the permissions of all selected jobs. The list of actions in the sidebar (Disable, Enable, Delete) is only displayed if the user has permissions to update ALL of the currently selected jobs.