### PR TITLE
fix for de-humanizing table names in error message

### DIFF
--- a/app/models/external_table.rb
+++ b/app/models/external_table.rb
@@ -36,7 +36,7 @@ class ExternalTable
     )
     true
   rescue PostgresLikeConnection::DatabaseError => e
-    errors.add(name, :TAKEN)
+    errors.add(name.parameterize.underscore , :TAKEN)
     false
   end
 


### PR DESCRIPTION
@prakash-alpine @kevin-alpine I tested this on 204 but its not working. Need to check from where error and getting displayed and add the same code there. I tried it out but couldnt figure it out. Please check.