### PR TITLE
Fix for [DEV-12309]  home page widget "site snapshot" takes very long…

### DIFF
--- a/app/models/dashboard/site_snapshot.rb
+++ b/app/models/dashboard/site_snapshot.rb
@@ -21,7 +21,9 @@ module Dashboard
         [Workspace, AssociatedDataset, Workfile, User].map do |model|
           {
               :model => model.to_s.underscore,
-              :total => model.count_in_scope(@user),
+              # Fix for DEV-12309.  Turning off scope filter until 5.7
+              #:total => model.count_in_scope(@user),
+              :total => model.count,
               :increment => changed_count(model)
           }
         end


### PR DESCRIPTION
Fix for [DEV-12309]  home page widget "site snapshot" takes very log to render and has no loading indicator.