### PR TITLE
12191: make sure all users can view 'Help & Support' dialog

### DIFF
--- a/app/assets/javascripts/templates/components/username_menu.hbs
+++ b/app/assets/javascripts/templates/components/username_menu.hbs
@@ -10,14 +10,12 @@
     </a>
   </li>
 
-    {{#ifAdmin}}
-      <li class='help_and_support'>
-        <a href="#" id="header_supportLink" class="supportLink">
-          {{t "help.help_and_support.title"}}
-        </a>
-      </li>
 
-    {{/ifAdmin}}
+  <li class='help_and_support'>
+    <a href="#" id="header_supportLink" class="supportLink">
+      {{t "help.help_and_support.title"}}
+    </a>
+  </li>
 
   <li class='underline'>
     <a href="#/about" id="header_aboutLink">

--- a/app/assets/javascripts/templates/dialogs/help_and_support.hbs
+++ b/app/assets/javascripts/templates/dialogs/help_and_support.hbs
@@ -30,11 +30,14 @@
     </p>
   </div>
 
-  <div class="messaging_block">
-    <h5>{{t "help.help_and_support.sub_title_2"}}</h5>
-    <p>{{{t "help.help_and_support.logs_download_message"}}}</p>
-    <button class="download_logs button_modalish">{{t "help.help_and_support.button.download_logs"}}</button>
-  </div>
+  {{#ifAdmin}}
+    <div class="messaging_block">
+      <h5>{{t "help.help_and_support.sub_title_2"}}</h5>
+
+      <p>{{{t "help.help_and_support.logs_download_message"}}}</p>
+      <button class="download_logs button_modalish">{{t "help.help_and_support.button.download_logs"}}</button>
+    </div>
+  {{/ifAdmin}}
 
 </div>
 


### PR DESCRIPTION
Currently, the "Help & Support" link does not appear at all, if you are not an admin.  This doesn't seem ideal.  Perhaps it would be better if just the "Download Logs" section doesn't appear, if you are not an admin?

https://alpine.atlassian.net/browse/DEV-12191

@mmilano please review and merge if you agree.