### PR TITLE
12192: allow showUrlTemplate to be a function which return null

### DIFF
--- a/app/assets/javascripts/mixins/urls.js
+++ b/app/assets/javascripts/mixins/urls.js
@@ -9,9 +9,15 @@ chorus.Mixins.Urls = {
         }
 
         var template = _.isFunction(this.showUrlTemplate) ? this.showUrlTemplate.apply(this, arguments) : this.showUrlTemplate;
-        var prefix = "#/";
-        var encodedFragment = new URI(Handlebars.compile(template, {noEscape: true})(this.attributes)).normalize().toString();
-        return prefix + encodedFragment;
+
+        if(template) {
+          var prefix = "#/";
+          var encodedFragment = new URI(Handlebars.compile(template, {noEscape: true})(this.attributes)).normalize().toString();
+          return prefix + encodedFragment;
+
+        } else {
+          return null;
+        }
     },
 
     showLink: function(text) {

--- a/app/assets/javascripts/models/hdfs_data_source.js
+++ b/app/assets/javascripts/models/hdfs_data_source.js
@@ -1,12 +1,19 @@
 chorus.models.HdfsDataSource = chorus.models.AbstractDataSource.extend({
     constructorName: "HdfsDataSource",
     urlTemplate: "hdfs_data_sources/{{id}}",
-    showUrlTemplate: "hdfs_data_sources/{{id}}/browse/",
     shared: true,
     entityType: "hdfs_data_source",
 
     isShared: function() {
         return true;
+    },
+
+    showUrlTemplate: function() {
+      if(this.get("isHdfsHive")) {
+        return null;
+      } else {
+        return "hdfs_data_sources/{{id}}/browse/";
+      }
     },
 
     providerIconUrl: function() {

--- a/spec/javascripts/mixins/urls_spec.js
+++ b/spec/javascripts/mixins/urls_spec.js
@@ -41,6 +41,18 @@ describe("chorus.Mixins.Urls", function() {
             });
         });
 
+        context("when showUrlTemplate is a function, but it returns null", function() {
+            beforeEach(function() {
+                this.object.showUrlTemplate = function(suffix) {
+                    return null;
+                };
+            });
+
+            it("calls the function with any arguments passed to 'showUrl', but returns null", function() {
+                expect(this.object.showUrl("banana")).toBe(null);
+            });
+        });
+
         context("when showUrlTemplate is not a function", function() {
             beforeEach(function() {
                 this.object.showUrlTemplate = "my_items/show/{{id}}";
@@ -51,7 +63,7 @@ describe("chorus.Mixins.Urls", function() {
                 expect(this.object.showUrl()).toBe("#/my_items/show/45");
             });
         });
-        
+
         context("#showLink", function() {
             it("shows the link with the model's name", function () {
                 expect(this.object.showLink().string).toBe('<a href="#/workspaces/45">Public</a>');


### PR DESCRIPTION
Hi @curran,

I reviewed #141 -- it is an ok fix, but I don't like it because it puts a reference is 'isHdfsHive' into `activity_presenters.js` ... which is a file which deals with displaying the activity stream for all model objects ... so for example, it will call `user.isHdfsHive()`, `worklet.isHdfsHive()` and so on for all the models in the `/javascripts/models` directory.

I noticed how link is created by using `showUrlTemplate` ... `showUrlTemplate` can also be a function and its used that way in several files, for example `alpineWorkfile`, `hdfsEntry` and so forth.  What I do here is to enhance the `chorus.Mixins.Urls.showUrl()` function to allow the `showUrlTemplate` function to return null, and in this case then, `showLink` doesn't return a link at all.

I like this better because, we put new abstract functionality into the abstract bits, and then modify `models/hdfs_data_source.js` specifically to use the new abstractly defined functionality.

KT