### PR TITLE
12441 Touchpoint 'Save and Close' does not save changed image

### DIFF
--- a/app/assets/javascripts/pages/workfiles/worklet_show_page.js
+++ b/app/assets/javascripts/pages/workfiles/worklet_show_page.js
@@ -117,6 +117,7 @@ chorus.pages.WorkletEditPage = chorus.pages.WorkletWorkspaceDisplayBase.extend({
         chorus.PageEvents.trigger("worklet:editor:save", "saving");
 
         if (this.editorViews['inputs'].content.saveParameters() && this.worklet.save(this.worklet.attributes, { wait: true })) {
+            this.worklet.saveFiles();
             chorus.toast('worklet.updated.success.toast', {name: this.worklet.get('fileName'), toastOpts: {type: "success"}});
             return true;
         } else {

--- a/app/assets/javascripts/views/workfiles/worklets/worklet_details_configuration_view.js
+++ b/app/assets/javascripts/views/workfiles/worklets/worklet_details_configuration_view.js
@@ -44,12 +44,17 @@ chorus.views.WorkletDetailsConfiguration = chorus.views.Base.extend({
         }
 
         var multipart = !window.jasmine;
+
         this.$("input[type=file]").fileupload({
             add: _.bind(this.desktopFileChosen, this),
             multipart: multipart,
             dataType: "text",
             dropZone: this.$("input[type=file]")
         });
+
+        if (this.model.files.length) {
+          this.loadNewImage(this.model.files[0].get('files')[0]);
+        }
     },
 
     hasUnsavedChanges: function() {
@@ -117,10 +122,6 @@ chorus.views.WorkletDetailsConfiguration = chorus.views.Base.extend({
     workletSaved: function(e) {
         this._hasUnsavedChanges = false;
         this.broadcastEditorState();
-        if (this.model.files.length) {
-            this.loadNewImage(this.model.files[0].get('files')[0]);
-            this.model.saveFiles();
-        }
     },
 
     workletSaveFailed: function(e) {


### PR DESCRIPTION
When `this.closePage();` is called, it must deconstruct the view objects, and it cancels any `workletSaved` callbacks.  So, we have to move the `worklet.saveFiles();` call into the actual 'save' machinery.

This also fixes another bug where, if you upload a changed image, and then switch tabs, the image would be broken.  This reloads the image.