### PR TITLE
Fix for [DEV-12064] Error message not appearing when attempting to vi…

### DIFF
--- a/app/controllers/data_sources_controller.rb
+++ b/app/controllers/data_sources_controller.rb
@@ -18,6 +18,7 @@ class DataSourcesController < ApplicationController
   end
 
   def show
+    Authority.authorize! :show, @data_source, current_user, { :or => :data_source_is_shared }
     present @data_source
   end
 

--- a/app/helpers/authority.rb
+++ b/app/helpers/authority.rb
@@ -30,7 +30,6 @@ module Authority
     # retreive user and object information
     legacy_action_allowed = handle_legacy_action(options, object, user) if options
     chorus_class = ChorusClass.search_permission_tree(object.class, activity_symbol)
-
     # If we don't have new-style permissions chorus_classs for the object,
     # and the old permissions didn't pass either, then raise access denied
     raise_access_denied(activity_symbol, object) if !legacy_action_allowed && chorus_class.nil?
@@ -158,6 +157,9 @@ module Authority
 
     elsif object.is_a?(Comment)
       Events::Base.for_dashboard_of(current_user).exists?(comment.event_id)
+
+    elsif object.is_a?(DataSource)
+        object.accessible_to(user)
 
     elsif object.is_a?(Workspace)
       object.visible_to? user

--- a/app/models/data_source.rb
+++ b/app/models/data_source.rb
@@ -129,7 +129,10 @@ class DataSource < ActiveRecord::Base
   end
 
   def account_for_user!(user)
-    account_for_user(user) || (raise ActiveRecord::RecordNotFound)
+    #account_for_user(user) || (raise ActiveRecord::RecordNotFound)
+    # Fix for DEV-12064. Error message not appearing when attempting to view a non-shared DB data source after upgrade.
+    # Always throw AccessDenied exception to force UI to pop-up credential dialog box.
+    account_for_user(user) || (raise Authority::AccessDenied.new("Unuthorized", :show, self))
   end
 
   def data_source


### PR DESCRIPTION
Fix for [DEV-12064] Error message not appearing when attempting to view a non-shared DB data source after upgrade.
