### PR TITLE
Eliminate gray line in empty jobs sidebar on multi-select

### DIFF
--- a/app/assets/javascripts/models/job.js
+++ b/app/assets/javascripts/models/job.js
@@ -22,7 +22,7 @@ chorus.models.Job = chorus.models.Base.extend({
     },
 
     canUpdate: function() {
-      this.workspace().canUpdate();
+      return this.workspace().canUpdate();
     },
 
     tasks: function () {

--- a/app/assets/javascripts/templates/multiple_selection_sidebar_menu.hbs
+++ b/app/assets/javascripts/templates/multiple_selection_sidebar_menu.hbs
@@ -1,14 +1,12 @@
-{{#if canUpdateSelected}}
-    {{#if actions}}
-        <label>{{t "sidebar.selected" count=modelCount}}</label>
-        <div class="actions">
-            <ul class="multiselect_actions">
-                {{#each actions}}
-                    <li class="action">
-                        <a href="#" class="{{name}}">{{message}}</a>
-                    </li>
-                {{/each}}
-            </ul>
-        </div>
-    {{/if}}
+{{#if actions}}
+    <label>{{t "sidebar.selected" count=modelCount}}</label>
+    <div class="actions">
+        <ul class="multiselect_actions">
+            {{#each actions}}
+                <li class="action">
+                    <a href="#" class="{{name}}">{{message}}</a>
+                </li>
+            {{/each}}
+        </ul>
+    </div>
 {{/if}}

--- a/app/assets/javascripts/views/multiple_selection_sidebar_menu.js
+++ b/app/assets/javascripts/views/multiple_selection_sidebar_menu.js
@@ -29,7 +29,23 @@ chorus.views.MultipleSelectionSidebarMenu = chorus.views.Base.include(
         },
 
         revealOnlyMultiActions: function () {
-            $('.multiple_selection').removeClass('hidden');
+
+            // Show the actions list only if the user has permissions
+            // to update all of the selected models.
+            var canUpdateSelected = this.selectedModels.every(function (model) {
+                if (typeof model.canUpdate == 'function') {
+                    return model.canUpdate();
+                } else {
+                    return true;
+                }
+            });
+
+            if(canUpdateSelected){
+                $('.multiple_selection').removeClass('hidden');
+            } else {
+                $('.multiple_selection').addClass('hidden');
+            }
+
             $('#sidebar').find('.primary').addClass('hidden');
         },
 
@@ -52,16 +68,7 @@ chorus.views.MultipleSelectionSidebarMenu = chorus.views.Base.include(
         additionalContext: function () {
             var actions = _.map(this.actions, this.templateValues);
 
-            var canUpdateSelected = this.selectedModels.every(function (model) {
-                if (typeof model.canUpdate == 'function') {
-                  return model.canUpdate();
-                } else {
-                  return true;
-                }
-            });
-
             return {
-                canUpdateSelected: canUpdateSelected,
                 selectedModels: this.selectedModels,
                 modelCount: this.selectedModels.length,
                 actions: actions

--- a/app/assets/javascripts/views/multiple_selection_sidebar_menu.js
+++ b/app/assets/javascripts/views/multiple_selection_sidebar_menu.js
@@ -42,8 +42,6 @@ chorus.views.MultipleSelectionSidebarMenu = chorus.views.Base.include(
 
             if(canUpdateSelected){
                 $('.multiple_selection').removeClass('hidden');
-            } else {
-                $('.multiple_selection').addClass('hidden');
             }
 
             $('#sidebar').find('.primary').addClass('hidden');


### PR DESCRIPTION
This pull request fixes the gray line issue pointed out by @maniiyer in https://alpine.atlassian.net/browse/DEV-9045

When multiple jobs are selected and user does not have permissions to update them, they were not shown but there was a gray line on the right side panel that should not have been there. I modified the solution such that when no actions are listed, the sidebar container is hidden (which removes the gray line) rather than having an empty template rendered into it.

Also added missing "return" statement in app/assets/javascripts/models/job.js canUpdate function. Verified locally that an admin can select multiple jobs and sees the actions, but a user without update permissions does not see the actions.