### PR TITLE
Changed activity presenter to not create links when model URL is null

### DIFF
--- a/app/assets/javascripts/presenters/activity_presenters.js
+++ b/app/assets/javascripts/presenters/activity_presenters.js
@@ -738,7 +738,16 @@
         },
 
         modelLink: function(model) {
-            return Handlebars.helpers.linkTo(model.showUrl(), model.name());
+            var url = model.showUrl();
+            
+            if(url){
+                return Handlebars.helpers.linkTo(url, model.name());
+            } else {
+
+                // If the URL is null, do not create an <a> element,
+                // so as not to give the user the impression the text is clickable.
+                return model.name();
+            }
         },
 
         dialogLink: function (model, linkTranslation) {


### PR DESCRIPTION
This fixes the issue that Hive Hadoop data sources were showing a link (`<a>` tag) with no `href` attribute. This was making the text look normal (black), but when the user hovered over it, it gave the cursor affordance that the text was clickable.

This pull request adds code that checks to see if the URL is defined before creating the link. If the URL is not defined (as in the case of Hive Hadoop data sources), the model name string is returned directly and not wrapped in an `<a>` element.