### PR TITLE
Docker (DO NOT MERGE)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.idea
+tmp
+postgres-db
+postgres
+chorus_appliance
+wiki-assets

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,75 @@
+FROM poklet/centos-baseimage
+
+MAINTAINER Kevin Trowbridge "kevin@alpinenow.com"
+
+COPY docker_build/templates/limits.conf /etc/security/limits.conf
+COPY docker_build/templates/90-nproc.conf /etc/security/limits.d/90-nproc.conf
+COPY docker_build/templates/sysctl.conf /etc/sysctl.conf
+
+RUN yum -y update
+
+# Install Oracle Java
+RUN curl -v -j -k -L -H "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/7u79-b15/jdk-7u79-linux-x64.rpm > jdk-7u79-linux-x64.rpm
+RUN rpm -ivh ./jdk-7u79-linux-x64.rpm
+RUN alternatives --install /usr/bin/java java /usr/java/jdk1.7.0_79/jre/bin/java 200000
+RUN alternatives --install /usr/bin/javac javac /usr/java/jdk1.7.0_79/bin/javac 200000
+RUN alternatives --install /usr/bin/jar jar /usr/java/jdk1.7.0_79/bin/jar 200000
+ENV JAVA_HOME /usr/java/latest
+RUN rm jdk-7u79-linux-x64.rpm
+
+# packages necessary for compiling jruby
+RUN yum install -y tar gcc-c++
+
+ENV JRUBY_VERSION 1.7.22
+RUN mkdir /opt/jruby \
+  && curl -fSL https://s3.amazonaws.com/jruby.org/downloads/${JRUBY_VERSION}/jruby-bin-${JRUBY_VERSION}.tar.gz -o /tmp/jruby.tar.gz \
+  && tar -zx --strip-components=1 -f /tmp/jruby.tar.gz -C /opt/jruby \
+  && rm /tmp/jruby.tar.gz \
+  && update-alternatives --install /usr/local/bin/ruby ruby /opt/jruby/bin/jruby 1
+ENV PATH /opt/jruby/bin:$PATH
+RUN chmod 777 -R /opt/jruby/lib/ruby/gems/shared /opt/jruby/bin
+
+# You need to install git to be able to use gems from git repositories.
+RUN yum install -y git
+
+# Docker is kind of weird about users: natively it wants to run everything as root.  There is a debate as to whether this
+# is good or not.  Chorus can't work that way mostly because of its current use of Postgresql: postgresql initdb cannot
+# be run as root.  So, I go to a good deal of trouble to run Chorus with a 'chorus' user.
+
+RUN groupadd chorus && useradd -g chorus chorus
+# RUN mkdir -p /home/chorus
+WORKDIR /home/chorus
+
+RUN echo 'gem: --no-rdoc --no-ri' >> /home/chorus/.gemrc
+
+RUN echo "CHORUS_HOME=/home/chorus; export CHORUS_HOME" >> /home/chorus/.bashrc
+RUN echo "PATH=/opt/jruby/bin:$CHORUS_HOME/bin:$CHORUS_HOME/postgres/bin:\$PATH; export PATH" >> /home/chorus/.bashrc
+RUN echo "JRUBY_OPTS='-X+O --client -J-Xmx2048m -J-Xms512m -J-Xmn128m -J-XX:MaxPermSize=128m -Xcext.enabled=true -J-Djava.library.path=$CHORUS_HOME/vendor/hadoop/lib/'; export JRUBY_OPTS" >> /home/chorus/.bashrc
+
+RUN chown -R chorus:chorus /home/chorus
+
+RUN runuser -l chorus -c 'gem install bundler'
+
+# Copy the Gemfile as well as the Gemfile.lock and install
+# the RubyGems. This is a separate step so the dependencies
+# will be cached unless changes to one of those two files
+# are made.
+COPY Gemfile Gemfile.lock ./
+COPY components components
+RUN chown -R chorus:chorus /home/chorus
+RUN runuser -l chorus -c 'bundle install --retry 5'
+
+COPY . ./
+RUN chown -R chorus:chorus /home/chorus
+RUN tar xzC /home/chorus -f /home/chorus/packaging/postgres/postgres-redhat6.2-9.2.4.tar.gz
+
+RUN runuser -l chorus -c 'rake development:init --trace'
+
+# Expose port 3000 to the Docker host, so we can access it
+# from the outside.
+EXPOSE 3000
+
+# The main command to run when the container starts. Also
+# tell the Rails dev server to bind to all interfaces by
+# default.
+CMD runuser -l chorus -c 'packaging/chorus_control.sh start'

--- a/docker_build/templates/90-nproc.conf
+++ b/docker_build/templates/90-nproc.conf
@@ -1,0 +1,14 @@
+# Default limit for number of user's processes to prevent
+# accidental fork bombs.
+# See rhbz #432903 for reasoning.
+
+*          soft    nproc     1024
+root       soft    nproc     unlimited
+
+# https://alpine.atlassian.net/wiki/display/CD5/Prepare+to+Install+Chorus
+* soft nofile 65536
+* hard nofile 65536
+* soft nproc 131072
+* hard nproc 131072
+
+# End of file

--- a/docker_build/templates/limits.conf
+++ b/docker_build/templates/limits.conf
@@ -1,0 +1,56 @@
+# /etc/security/limits.conf
+#
+#Each line describes a limit for a user in the form:
+#
+#<domain>        <type>  <item>  <value>
+#
+#Where:
+#<domain> can be:
+#        - a user name
+#        - a group name, with @group syntax
+#        - the wildcard *, for default entry
+#        - the wildcard %, can be also used with %group syntax,
+#                 for maxlogin limit
+#
+#<type> can have the two values:
+#        - "soft" for enforcing the soft limits
+#        - "hard" for enforcing hard limits
+#
+#<item> can be one of the following:
+#        - core - limits the core file size (KB)
+#        - data - max data size (KB)
+#        - fsize - maximum filesize (KB)
+#        - memlock - max locked-in-memory address space (KB)
+#        - nofile - max number of open file descriptors
+#        - rss - max resident set size (KB)
+#        - stack - max stack size (KB)
+#        - cpu - max CPU time (MIN)
+#        - nproc - max number of processes
+#        - as - address space limit (KB)
+#        - maxlogins - max number of logins for this user
+#        - maxsyslogins - max number of logins on the system
+#        - priority - the priority to run user process with
+#        - locks - max number of file locks the user can hold
+#        - sigpending - max number of pending signals
+#        - msgqueue - max memory used by POSIX message queues (bytes)
+#        - nice - max nice priority allowed to raise to values: [-20, 19]
+#        - rtprio - max realtime priority
+#
+#<domain>      <type>  <item>         <value>
+#
+
+#*               soft    core            0
+#*               hard    rss             10000
+#@student        hard    nproc           20
+#@faculty        soft    nproc           20
+#@faculty        hard    nproc           50
+#ftp             hard    nproc           0
+#@student        -       maxlogins       4
+
+# https://alpine.atlassian.net/wiki/display/CD5/Prepare+to+Install+Chorus
+* soft nofile 65536
+* hard nofile 65536
+* soft nproc 131072
+* hard nproc 131072
+
+# End of file

--- a/docker_build/templates/sysctl.conf
+++ b/docker_build/templates/sysctl.conf
@@ -1,0 +1,48 @@
+# Kernel sysctl configuration file for Red Hat Linux
+#
+# For binary values, 0 is disabled, 1 is enabled.  See sysctl(8) and
+# sysctl.conf(5) for more details.
+
+# Controls IP packet forwarding
+net.ipv4.ip_forward = 0
+
+# Controls source route verification
+net.ipv4.conf.default.rp_filter = 1
+
+# Do not accept source routing
+net.ipv4.conf.default.accept_source_route = 0
+
+# Controls the System Request debugging functionality of the kernel
+kernel.sysrq = 0
+
+# Controls whether core dumps will append the PID to the core filename.
+# Useful for debugging multi-threaded applications.
+kernel.core_uses_pid = 1
+
+# Controls the use of TCP syncookies
+net.ipv4.tcp_syncookies = 1
+
+# Disable netfilter on bridges.
+net.bridge.bridge-nf-call-ip6tables = 0
+net.bridge.bridge-nf-call-iptables = 0
+net.bridge.bridge-nf-call-arptables = 0
+
+# Controls the default maxmimum size of a mesage queue
+kernel.msgmnb = 65536
+
+# Controls the maximum size of a message, in bytes
+kernel.msgmax = 65536
+
+# Controls the maximum shared segment size, in bytes
+# kernel.shmmax = 68719476736
+
+# https://alpine.atlassian.net/wiki/display/CD5/Prepare+to+Install+Chorus
+kernel.shmmax = 500000000
+
+# Controls the maximum number of shared memory segments, in pages
+# kernel.shmall = 4294967296
+
+# https://alpine.atlassian.net/wiki/display/CD5/Prepare+to+Install+Chorus
+kernel.shmall = 4000000000
+
+# End of file

--- a/lib/tasks/development.rake
+++ b/lib/tasks/development.rake
@@ -32,18 +32,27 @@ namespace :development do
   desc "Initialize the database and create the database user used by Chorus"
   task :init_database => [:generate_database_yml] do
     root = Pathname.new(__FILE__).dirname.join("../..")
-    postgres_port = `ruby #{File.join(root, 'packaging', 'get_postgres_port.rb')}`.chomp
-    next if root.join("postgres-db").exist?
 
-    `DYLD_LIBRARY_PATH=#{root}/postgres/lib LD_LIBRARY_PATH=#{root}/postgres/lib #{root}/postgres/bin/initdb -D #{root}/postgres-db -E utf8`
-    `CHORUS_HOME=#{root} #{root}/packaging/chorus_control.sh start postgres`
-    `DYLD_LIBRARY_PATH=#{root}/postgres/lib LD_LIBRARY_PATH=#{root}/postgres/lib #{root}/postgres/bin/createuser -hlocalhost -p #{postgres_port} -sdr postgres_chorus`
+    postgres_port = `ruby #{File.join(root, 'packaging', 'get_postgres_port.rb')}`.chomp
+
+    # Give the poor developer a clue as to what is wrong!
+    if root.join("postgres-db").exist?
+      p "The postgres-db directory already exists, so exiting."
+      next
+    end
+
+    ENV['DYLD_LIBRARY_PATH'] = "#{root}/postgres/lib"
+    ENV['LD_LIBRARY_PATH'] = "#{root}/postgres/lib"
+    ENV['CHORUS_HOME'] = "#{root}"
+    `#{root}/postgres/bin/initdb -D #{root}/postgres-db -E utf8`
+    `#{root}/packaging/chorus_control.sh start postgres`
+    `#{root}/postgres/bin/createuser -hlocalhost -p #{postgres_port} -sdr postgres_chorus`
 
     Rake::Task["db:create"].invoke
     Rake::Task["db:migrate"].invoke
     Rake::Task["db:seed_permissions"].invoke
     Rake::Task["db:seed_development"].invoke
-    `CHORUS_HOME=#{root} #{root}/packaging/chorus_control.sh stop postgres`
+    `#{root}/packaging/chorus_control.sh stop postgres`
   end
 
   desc "Initialize development environment.  Includes initializing the database and creating secret tokens"


### PR DESCRIPTION
I'm using this branch to communicate my findings about Docker.  

There are some things we have to think about before using Docker for production (see below), but we should explore this technology.  Docker can simplify our lives.  But it has a learning curve and adds some complications of its own.

# Using this branch

Docker itself only runs on Linux.  So, in order to use it on OSX you must run Linux in a virtual machine.  Docker comes with a tool to help you manage this called "docker-machine"

1) Install Docker -- here are the OSX instructions: http://docs.docker.com/mac/step_one/

2) Once installed, you must create a docker-machine instance which has more memory than the default ... (if, by following the install instructions, you already have created one -- you can tell by running `docker-machine ls` -- you can delete it with a simple `docker-machine rm default`).  

To create the larger 4GB memory instance: 
```
docker-machine create --driver virtualbox --virtualbox-cpu-count 2 --virtualbox-memory "4096" --virtualbox-disk-size "10000" default
```

3) Then connect the the running docker-machine with the docker command: 
```
eval "$(docker-machine env default)"
```

4) Now, you are ready to use the "docker" command. Let's get a first easy win by downloading and running this Chorus docker container that I have created: 
```
wget https://dl.dropboxusercontent.com/u/37621685/chorus.tar.gz
docker load --input chorus.tar.gz
```

5) You can determine the IP of your docker-machine via: 
```
docker-machine ip default
```

6) Now, run the image:
```
docker run -p 3000:3000 chorus
```
_(`-p 3000:3000` bridges port 3000 across on the docker-machine.)_

7) Now, form the URL to access Chorus like so:
```
http://<docker-machine IP>:3000/#/login
```
It should look something like: 
http://192.168.99.100:3000/#/login

Navigate to this URL in the browser and you will see the Chorus login page.

8) Viewing the logs -- the booted / instantiated image is called a "container" -- it has its own tag.  Find it with the command `docker ps`.  (For example, mine is "distracted_bhaskara".) Then, using that, you can attach a process to the running container like so:
```
docker ps
docker exec -it distracted_bhaskara bash
(now you're in a shell inside the running container)
tail -f log/*
```

# Building your own Docker container via the Dockerfile

Assuming you have configured your docker-machine and connected it to the docker command as described above, just follow these steps:
1) `git fetch origin docker`
2) `git checkout docker`
3) `docker build -t chorus .`

... when this has completed you can see the freshly build docker image via:
```
docker images
```

... you can then run the image via:
```
docker run -p 3000:3000 chorus
```

# The Benefits of Docker

You can see, already, the wonky circuitous steps that are in [Getting started with Chorus Development](https://github.com/Chorus/chorus/wiki/Getting-started-with-Chorus-development) can mostly go away and instead be a part of the Dockerfile.  

For now I've changed as little as possible, however if we were to adopt this approach, the world of unix packages would be available to us via package managers: we would no longer need the custom built static binaries of [postgresql](https://github.com/Chorus/chorus/blob/master/packaging/build-postgres.sh), solr, [nginx](https://github.com/Chorus/chorus/blob/master/packaging/build-nginx.sh), [imagemagick](https://github.com/Chorus/chorus/blob/master/packaging/build-imagemagick.sh), so we could delete all that.  Instead we'd install the packages via yum in the Dockerfile.

A lot of the packaging and installation scripts would be obsolete: we would not need [jetpack](https://github.com/square/jetpack).  Without jetpack then we can upgrade to the most modern version of rack and use a more reputable application server like [passenger](https://www.phusionpassenger.com/).

Our production deployment would be more declarative: the directory structure would not need to change between the development and production environments.  We would [keep the database data outside of the container](http://cloud-mechanic.blogspot.com/2014/10/storage-concepts-in-docker-persistent.html).  So, upgrading would be about swapping out containers, instead of the capistrano style solution we have now.

All in all it could be a much simpler and stabler solution.

# Using Docker for Development?

This is a really nice article: http://www.ybrikman.com/writing/2015/05/19/docker-osx-dev/
A related StackOverflow post: http://stackoverflow.com/questions/30090007/whats-the-right-way-to-setup-a-development-environment-on-os-x-with-docker

He brings up one issue I think we will need to solve: "Except for one thing: mounted folders ... the system it uses to mount folders, called vboxsf, is agonizingly slow."  Mounted folders, that is, the synchronized filesystem that you use to communicate you code changes into the VM, is unworkable.  So that's a big problem but by reading through that article (which is ~4mos old) there are [a few](https://github.com/adlogix/docker-machine-nfs) [solutions](https://github.com/brikis98/docker-osx-dev) in the works.

# Using Docker for Production?

Some of these issues may be insurmountable right now -- I don't know what the attitude is towards running root processes and what versions of CentOS we must support.  However it seems probably that within 6-18mos these problems may fade away.  In that case we would be very prescient to use docker for development, now.

Here are some issues I discovered:
* You have to run the [docker](http://askubuntu.com/questions/477551/how-can-i-use-docker-without-sudo) [daemon](http://unix.stackexchange.com/questions/156938/why-does-docker-need-root-privileges) [as root](https://github.com/docker/docker/issues/1034).  They [are trying to fix this](http://www.informationweek.com/software/enterprise-applications/docker-to-defang-root-privilege-access/d/d-id/1321023) though.
* It's a bit murky as to whether [it can work on CentOS 6](http://stackoverflow.com/questions/28483379/installing-docker-on-centos-6-6) -- it definitely works on [CentOS 7](https://docs.docker.com/installation/centos/).  Maybe the newest version requires CentOS 7.
* I'm not sure how how you might be able to install the docker daemon itself without a package manager.  I looked into this briefly but it seemed like I might be asking a lot.  It's too bad since, there's an OSX installer, you would think they might have created a binary linux installer as well.  :(

Here's docker's article on security: https://docs.docker.com/articles/security/

If you google "enterprise docker" you can find some interesting articles which remind me of our situation:
http://www.pcworld.com/article/2939852/docker-offers-enterprise-support-software-for-containers.html
https://zeltser.com/security-risks-and-benefits-of-docker-application/  
http://venturebeat.com/2015/06/30/10-myths-about-enterprise-adoption-of-docker/