### PR TITLE
DEV-12995 prevent excessive roles in roles_users table

### DIFF
--- a/app/helpers/authority.rb
+++ b/app/helpers/authority.rb
@@ -186,10 +186,10 @@ module Authority
   end
 
   def self.retrieve_roles(user)
-    roles = user.roles.clone
+    roles = user.roles.to_a
 
     user.groups.each do |group|
-      roles << group.roles if group.roles.empty? == false
+      roles.concat(group.roles) if group.roles.empty? == false
     end
 
     roles


### PR DESCRIPTION
@midnighteuler @jleealpine 

'roles' was supposed to be an array but it was actually an Association