### PR TITLE
for Release_5.7, restart indexer every 24h

### DIFF
--- a/app/services/service_scheduler.rb
+++ b/app/services/service_scheduler.rb
@@ -37,6 +37,11 @@ class ServiceScheduler
       SolrIndexer.SolrQC.enqueue_if_not_queued('SolrIndexer.refresh_external_data')
     end
 
+    every(ChorusConfig.instance['restart_indexer_interval_hours'].hours, 'chorus_control.sh restart indexer') {
+      chorus_control = File.expand_path("../../../packaging/chorus_control.sh", __FILE__)
+      `#{chorus_control} restart indexer`
+    }
+
     every(ChorusConfig.instance['reset_counter_cache_interval_hours'].hours, 'Tag.reset_all_counters') do
       QC.enqueue_if_not_queued('Tag.reset_all_counters')
     end

--- a/config/chorus.defaults.properties
+++ b/config/chorus.defaults.properties
@@ -23,6 +23,7 @@ delete_unimported_csv_files_after_hours = 24
 instance_poll_interval_minutes = 5
 reindex_search_data_interval_hours = 24
 reset_counter_cache_interval_hours = 24
+restart_indexer_interval_hours = 24
 
 sandbox_recommended_size_in_gb = 5
 

--- a/config/chorus.properties.example
+++ b/config/chorus.properties.example
@@ -31,6 +31,7 @@ delete_unimported_csv_files_after_hours = 12
 instance_poll_interval_minutes = 5
 reindex_search_data_interval_hours = 24
 reset_counter_cache_interval_hours = 24
+restart_indexer_interval_hours = 24
 
 sandbox_recommended_size_in_gb = 5
 


### PR DESCRIPTION
In [DEV-13301: Chorus indexer process hangs](https://alpine.atlassian.net/browse/DEV-13301) we had to fess up to the fact that the indexer process is buggy and hangs periodically.

We don't  have time to fix this properly in 5.7, but as a stopgap measure, we will restart the indexer every 24 hours.  Restarting ruby processes every 24 hours is a common practice (I know this is done by Heroku, for example) to deal with memory leaks and keep processes running properly.

#indexer #hanging #workaround