### PR TITLE
Hive JDBC controller updates to allow incomplete

### DIFF
--- a/app/models/data_source.rb
+++ b/app/models/data_source.rb
@@ -226,11 +226,10 @@ class DataSource < ActiveRecord::Base
   end
 
   def validate_owner?
-    self.changed.include?('host')        ||
-    self.changed.include?('port')        ||
-    self.changed.include?('db_name')     ||
-    self.changed.include?('db_username') ||
-    self.changed.include?('db_password')
+    (self.changed.include?('host')        ||
+    self.changed.include?('port')         ||
+    self.changed.include?('db_name'))     &&
+    should_update_account? == false
   end
 
   def enqueue_refresh

--- a/app/services/jdbc_hive/data_source_registrar.rb
+++ b/app/services/jdbc_hive/data_source_registrar.rb
@@ -5,7 +5,7 @@ module JdbcHive
       data_source = JdbcHiveDataSource.new(data_source_attributes)
       data_source[:shared] = data_source_attributes[:shared]
       data_source.owner = owner
-      data_source.save!
+      data_source.save_if_incomplete!(data_source_attributes)
       Events::DataSourceCreated.by(owner).add(:data_source => data_source)
       data_source
     end
@@ -16,7 +16,8 @@ module JdbcHive
       data_source_attributes.delete(:owner)
 
       data_source.attributes = data_source_attributes
-      data_source.save!
+
+      data_source.save_if_incomplete!(data_source_attributes)
       data_source
 
     end


### PR DESCRIPTION
@jleealpine can you please look over this? It's supposed to allow incomplete saving for hive JDBC and also fix a problem where the owner account validation would happen before the account was updated, so the validation would always fail if you had bad credentials before updating 