### PR TITLE
Add redshift on jdbc_overrides

### DIFF
--- a/components/core/app/mixins/sequel/extensions/additional_jdbc_drivers.rb
+++ b/components/core/app/mixins/sequel/extensions/additional_jdbc_drivers.rb
@@ -5,7 +5,8 @@ module Sequel
         teradata: ->(db) { com.teradata.jdbc.TeraDriver },
         vertica: ->(db) { com.vertica.jdbc.Driver },
         hive2: ->(db) { org.apache.hive.jdbc.HiveDriver },
-        hive: ->(db) { org.apache.hadoop.hive.jdbc.HiveDriver }
+        hive: ->(db) { org.apache.hadoop.hive.jdbc.HiveDriver },
+        redshift: ->(db) { com.amazon.redshift.jdbc41.Driver }
     }
 
     MAP.each do |key, driver|

--- a/components/core/app/services/jdbc_overrides.rb
+++ b/components/core/app/services/jdbc_overrides.rb
@@ -3,6 +3,7 @@ require_relative 'jdbc_overrides/sqlserver_overrides'
 require_relative 'jdbc_overrides/mariadb_overrides'
 require_relative 'jdbc_overrides/mysql_overrides'
 require_relative 'jdbc_overrides/hive2_overrides'
+require_relative 'jdbc_overrides/redshift_overrides'
 
 module JdbcOverrides
   #module OverrideTemplate
@@ -25,6 +26,7 @@ module JdbcOverrides
       when /jdbc:mariadb:/ then JdbcOverrides::Mariadb
       when /jdbc:mysql:/ then JdbcOverrides::MySQL
       when /jdbc:hive2:/ then JdbcOverrides::Hive2
+      when /jdbc:redshift:/ then JdbcOverrides::Redshift
       else nil
     end
   end

--- a/components/core/app/services/jdbc_overrides/redshift_overrides.rb
+++ b/components/core/app/services/jdbc_overrides/redshift_overrides.rb
@@ -1,0 +1,12 @@
+module JdbcOverrides
+  module Redshift
+    module ConnectionOverrides
+    end
+
+    module CancelableQueryOverrides
+    end
+
+    module DatasetOverrides
+    end
+  end
+end


### PR DESCRIPTION
AWS redshift can connect with postgresql jdbc driver, but I cannot use it on chorus.
So I added redshift jdbc driver settings.

* It needs redshift jdbc driver.
http://docs.aws.amazon.com/redshift/latest/mgmt/configure-jdbc-connection.html